### PR TITLE
Added matrix transpose example showing tile and cache uses

### DIFF
--- a/Submissions/Fortran/matrix_transpose_cache_tile_7a35bbe4f2464f50a4da8ecca732534b/driver.F90
+++ b/Submissions/Fortran/matrix_transpose_cache_tile_7a35bbe4f2464f50a4da8ecca732534b/driver.F90
@@ -1,0 +1,339 @@
+
+  ! Name: David Appelhans
+  ! Email: dappelha@gmail.com
+  ! GitHub Username: dappelha
+  ! Date Code Written: 10/17/2022
+  ! Features Referenced: Parallel, Kernels, Cache, Tiled
+  ! OpenACC Version: 3.2
+  ! Compiler Used: nvfortran 22.3
+
+  
+  ! OpenACC examples of how to use the cache and tile clause to improve performance of codes with strided access patterns (for example matrix transpose).
+  ! GPUs memory performance is best when reads and writes to global memory are stride 1 (coalesced memory access).
+  ! Data layout may not lead to this naturally, but
+  ! 1. using the tile clause can give hints to the compiler about data locality, which can help group access into fewer cache lines
+  ! 2. Using the cache clause can give the developer a gang private scratch pad where the assignment of vectors to loop indices can be reversed to achieve coalesced accesses.
+  ! 1 is similar to traditional cache blocking and 2 is similar to using the shared memory scratch space of a GPU.
+
+
+
+module transposes
+
+contains
+
+  subroutine reference(A,B,n)
+    ! Reference implementation for correctness checking
+    implicit none
+
+    ! passed variables
+    integer, intent(in) :: n
+    real(kind=8), intent(in) :: A(n,n)
+    real(kind=8), intent(out) :: B(n,n)   
+
+    ! local variables
+    integer :: i,j
+
+    do j=1,n
+       do i=1,n
+          B(j,i) = A(i,j)
+       enddo
+    enddo
+    
+    return
+
+  end subroutine reference
+  
+  
+  subroutine transpose_kernels(A,B,n) 
+    implicit none
+
+    ! passed variables
+    integer, intent(in) :: n
+    real(kind=8), intent(in) :: A(n,n)
+    real(kind=8), intent(out) :: B(n,n)   
+
+    ! local variables
+    integer :: i,j
+
+    !$acc kernels present(A,B)
+    do j=1,n
+       do i=1,n
+          B(j,i) = A(i,j) ! coallesced read, uncoalesced write
+       enddo
+    enddo
+    !$acc end kernels
+
+    ! note same result on nvfortran 22.3 if used
+    !!!    !$acc parallel loop gang vector collapse(2)
+    
+    return
+
+  end subroutine transpose_kernels
+
+  subroutine transpose_accgangvectcollapse(A,B,n) 
+    implicit none
+
+    ! passed variables
+    real(kind=8), intent(in) :: A(:,:)
+    real(kind=8), intent(out) :: B(:,:)   
+    integer, intent(in) :: n
+    ! local variables
+    integer :: i,j
+
+    !$acc parallel loop gang vector collapse(2)
+    do j=1,n
+       do i=1,n
+          B(j,i) = A(i,j) ! coallesced read, uncoalesced write
+       enddo
+    enddo
+    !$acc end parallel
+    
+    return
+
+  end subroutine transpose_accgangvectcollapse
+
+  
+  subroutine transpose_accgangvecttile(A,B,n) 
+    implicit none
+
+    ! passed variables
+    real(kind=8), intent(in) :: A(:,:)
+    real(kind=8), intent(out) :: B(:,:)   
+    integer, intent(in) :: n
+    ! local variables
+    integer :: i,j
+
+    !$acc parallel loop gang vector tile(16,16)
+    do j=1,n
+       do i=1,n
+          B(j,i) = A(i,j) ! coallesced read, uncoalesced write
+       enddo
+    enddo
+    !$acc end parallel
+    
+    return
+
+  end subroutine transpose_accgangvecttile
+
+
+  
+  subroutine transpose_acc2gang2vect(A,B,n) 
+    implicit none
+
+    ! passed variables
+    real(kind=8), intent(in) :: A(:,:)
+    real(kind=8), intent(out) :: B(:,:)   
+    integer, intent(in) :: n
+    ! local variables
+    integer :: i,j, istart, jstart, ii, jj
+    integer :: xthreads, ythreads
+
+    
+    ! pick good set of launch params
+    xthreads = 16
+    ythreads = 16
+
+    !$acc parallel loop gang collapse(2) vector_length(16*16)
+    do jstart=1, n, ythreads 
+       do istart=1, n, xthreads 
+          !$acc loop vector collapse(2)
+          do jj = 1, ythreads
+             do ii = 1, xthreads
+                i = ii+istart-1
+                j = jj+jstart-1
+                if(i<=n .AND. j<=n) then
+                   B(j,i) = A(i,j)
+                endif
+             enddo
+          enddo
+
+       enddo
+    enddo    
+    !$acc end parallel
+    
+    return
+
+  end subroutine transpose_acc2gang2vect
+
+
+  subroutine transpose_acc_cache(A,B,n) 
+    implicit none
+
+    ! passed variables
+    real(kind=8), intent(in) :: A(:,:)
+    real(kind=8), intent(out) :: B(:,:)   
+    integer, intent(in) :: n
+    ! local variables
+    integer :: i,j, istart, jstart, ii, jj
+    integer :: xthreads, ythreads
+    real(kind=8) :: scratchpad(16,16)
+    
+    ! pick good set of launch params
+    xthreads = 16
+    ythreads = 16
+
+    !$acc parallel loop gang collapse(2) vector_length(16*16) private(scratchpad)
+    do jstart=1, n, ythreads 
+       do istart=1, n, xthreads
+          !$acc cache(scratchpad(:,:))
+          !$acc loop vector collapse(2)
+          do jj = 1, ythreads
+             do ii = 1, xthreads
+                i = ii+istart-1
+                j = jj+jstart-1
+                if(i<=n .AND. j<=n) then
+                   scratchpad(ii,jj) = A(i,j) ! coalesced read from global mem
+                endif
+             enddo
+          enddo ! <- implicit sync point here
+          !$acc loop vector collapse(2)
+          do ii = 1, xthreads
+             do jj = 1, ythreads
+                i = ii+istart-1
+                j = jj+jstart-1
+                if(i<=n .AND. j<=n) then
+                   B(j,i) = scratchpad(ii,jj) ! coalesced write to global mem
+                endif
+             enddo
+          enddo
+       enddo
+    enddo    
+    !$acc end parallel
+    
+    return
+
+  end subroutine transpose_acc_cache
+
+  
+end module transposes
+
+
+program main
+  use transposes
+  use omp_lib
+  use iso_c_binding
+  implicit none
+  integer :: n 
+  
+
+  character(len=20) :: buffer  
+  real(kind=8), allocatable :: A(:,:), B(:,:), B_ref(:,:)
+  !real(kind=8), device, allocatable :: d_A(:,:), d_B(:,:)
+  real(kind=8) :: t1, t2, T, mem
+  integer :: ierr, i, j, testnum, q
+  real(kind=8),allocatable :: table(:,:)
+
+
+  allocate( table(12*1024/128,5) )
+  
+  open (unit = 22, file = "/dev/stdout")
+  write(22,*) "OpenACC Matrix Transpose Benchmarking"
+ 
+  
+  write(22,"( 6(A16,2X) )") "R+W Bytes (MB)", "kernels     ", "gangvectcollapse", "tile clause", "manual tile", "cache clause" 
+  ! Total size of the data
+  do n = 256, 4*1024, 128
+
+     q = q + 1
+
+     mem = 8*real(n*n,kind=8)/real(1000*1000*1000,kind=8)
+
+     ! This kernel establishes the GPU context, which would otherwise
+     ! be done on the first time running the kernels that we are timing (skewing the timings).
+     !$acc kernels
+     !do nothing, dummy kernel. 
+     !$acc end kernels
+
+     ! TEST 1
+
+     testnum=1
+     allocate(A(n,n), B(n,n))
+     !$acc enter data create(A,B)     
+     t1 = omp_get_wtime()
+     call transpose_kernels(A,B,n)
+     t2 = omp_get_wtime()
+     T = t2-t1
+
+     table(q,testnum)=2*mem/T
+
+     !$acc exit data delete(A,B)
+
+     deallocate(A,B)
+
+     ! TEST 2
+
+     testnum=2
+     allocate(A(n,n), B(n,n))
+     !$acc enter data create(A,B)     
+     t1 = omp_get_wtime()
+     call transpose_accgangvectcollapse(A,B,n)
+     t2 = omp_get_wtime()
+     T = t2-t1
+
+     table(q,testnum)=2*mem/T
+
+     !$acc exit data delete(A,B)
+
+     deallocate(A,B)
+
+
+     ! TEST 3
+
+     testnum=3
+     allocate(A(n,n), B(n,n))
+     !$acc enter data create(A,B)     
+     t1 = omp_get_wtime()
+     call transpose_accgangvecttile(A,B,n)
+     t2 = omp_get_wtime()
+     T = t2-t1
+
+     table(q,testnum)=2*mem/T
+
+     !$acc exit data delete(A,B)
+
+     deallocate(A,B)
+
+
+     ! TEST 4
+
+     testnum=4
+     allocate(A(n,n), B(n,n))
+     !$acc enter data create(A,B)     
+     t1 = omp_get_wtime()
+     call transpose_acc2gang2vect(A,B,n)
+     t2 = omp_get_wtime()
+     T = t2-t1
+
+     table(q,testnum)=2*mem/T
+
+     !$acc exit data delete(A,B)
+
+     deallocate(A,B)
+
+
+     ! TEST 5
+
+     testnum=5
+     allocate(A(n,n), B(n,n))
+     !$acc enter data create(A,B)     
+     t1 = omp_get_wtime()
+     call transpose_acc_cache(A,B,n)
+     t2 = omp_get_wtime()
+     T = t2-t1
+
+     table(q,testnum)=2*mem/T
+
+     !$acc exit data delete(A,B)
+
+     deallocate(A,B)
+
+     
+     write(22,"(6(f9.2,10X))") 2*mem*1000, table(q,:)
+     !write(22,"(f9.4,T15,5(2X,f9.2))") 2*mem*1000, table(q,:)
+     
+  enddo
+
+
+  
+  print*, "completed"
+end program main

--- a/Submissions/Fortran/matrix_transpose_cache_tile_7a35bbe4f2464f50a4da8ecca732534b/makefile
+++ b/Submissions/Fortran/matrix_transpose_cache_tile_7a35bbe4f2464f50a4da8ecca732534b/makefile
@@ -1,0 +1,20 @@
+# nvhpc compiler
+	F90=nvfortran
+	#CUDAFLAGS = -Mcuda=cc70,nordc,maxregcount:64,ptxinfo,lineinfo,nounroll -fast -Mfprelaxed -L/usr/local/cuda/lib64 -lnvToolsExt
+	CUDAFLAGS = -Mcuda=cc70,nordc,maxregcount:64,ptxinfo,lineinfo,nounroll -Mfprelaxed 
+	#CUDAFLAGS+= -Minfo=inline,accel -acc=noautopar
+	CUDAFLAGS+= -acc=noautopar	
+	F90FLAGS=-gopt -mp -Minfo -Mnounroll -Mnovect -fast
+	#F90FLAGS=-gopt -mp -Minfo -Munroll -Mnovect
+
+
+
+build: driver.o
+	${F90} -o ${comp}test driver.o ${F90FLAGS} ${CUDAFLAGS} ${LINKFLAGS}
+
+driver.o: driver.F90
+	${F90} -c -o driver.o driver.F90 ${F90FLAGS} ${CUDAFLAGS}
+
+clean:
+	rm -f ${comp}test *.o *.mod
+

--- a/Submissions/Fortran/matrix_transpose_cache_tile_7a35bbe4f2464f50a4da8ecca732534b/makefile
+++ b/Submissions/Fortran/matrix_transpose_cache_tile_7a35bbe4f2464f50a4da8ecca732534b/makefile
@@ -1,19 +1,18 @@
 # nvhpc compiler
 	F90=nvfortran
-	#CUDAFLAGS = -Mcuda=cc70,nordc,maxregcount:64,ptxinfo,lineinfo,nounroll -fast -Mfprelaxed -L/usr/local/cuda/lib64 -lnvToolsExt
-	CUDAFLAGS = -Mcuda=cc70,nordc,maxregcount:64,ptxinfo,lineinfo,nounroll -Mfprelaxed 
-	#CUDAFLAGS+= -Minfo=inline,accel -acc=noautopar
-	CUDAFLAGS+= -acc=noautopar	
-	F90FLAGS=-gopt -mp -Minfo -Mnounroll -Mnovect -fast
-	#F90FLAGS=-gopt -mp -Minfo -Munroll -Mnovect
+	#GPUFLAGS = -Mcuda=cc70,nordc,maxregcount:64,ptxinfo,lineinfo,unroll -Mfprelaxed
+	GPUFLAGS = -Mcuda=cc70,nordc,maxregcount:64,ptxinfo,lineinfo -Mfprelaxed
+	GPUFLAGS+= -acc=noautopar	
+	#	F90FLAGS=-gopt -mp -Minfo -Munroll -Mnovect -fast
+	F90FLAGS=-gopt -mp -Minfo -fast
 
 
 
 build: driver.o
-	${F90} -o ${comp}test driver.o ${F90FLAGS} ${CUDAFLAGS} ${LINKFLAGS}
+	${F90} -o ${comp}test driver.o ${F90FLAGS} ${GPUFLAGS} ${LINKFLAGS}
 
 driver.o: driver.F90
-	${F90} -c -o driver.o driver.F90 ${F90FLAGS} ${CUDAFLAGS}
+	${F90} -c -o driver.o driver.F90 ${F90FLAGS} ${GPUFLAGS}
 
 clean:
 	rm -f ${comp}test *.o *.mod


### PR DESCRIPTION
This example shows how to use the tile and cache clause (separately) to improve performance when codes access data in a non-coalesced fashion. Compares with a kernel and parallel approach to compute bandwidth. On a V100 you will see results like this:

```
  R+W Bytes (MB)      kernels       gangvectcollapse       tile clause       manual tile      cache clause
     1.05              34.91              69.81              69.81              74.54              81.45
     2.36             102.02             130.21             147.70             157.07             183.25
     4.19             144.20             174.18             231.48             244.34             279.24
     6.55             177.34             211.44             205.13             286.33             327.24
     9.44             213.96             235.61             314.15             338.31             363.14
    12.85             225.42             247.14             366.50             376.76             427.59
    16.78             261.59             279.24             335.09             399.82             466.02
    21.23             269.06             291.05             424.10             408.53             492.05
    26.21             279.06             294.78             445.15             422.89             523.58
    31.72             268.77             278.33             434.77             433.36             538.63
    37.75             292.66             309.84             465.68             471.22             563.45
    44.30             280.69             280.27             443.48             430.13             568.25
    51.38             256.86             267.38             389.00             383.46             577.76
    58.98             308.47             318.80             468.54             460.69             601.92
    67.11             316.62             322.79             493.82             486.14             610.57
    75.76             308.20             309.10             440.72             440.11             611.07
    84.93             262.14             265.46             418.62             418.12             611.05
    94.63             271.87             272.80             442.01             432.38             635.08
   104.86             298.78             299.59             447.87             447.87             631.00
   115.61             251.89             252.41             411.27             415.85             635.50
   126.88             235.78             234.95             372.14             377.69             627.55
   138.67             227.38             229.26             396.21             399.48             641.99
   150.99             198.72             200.48             360.45             366.50             599.17
   163.84             218.99             219.90             412.73             408.56             650.14
   177.21             175.80             177.60             360.11             354.44             637.45
   191.10             158.72             163.21             374.73             372.46             637.16
   205.52             168.20             167.61             377.91             375.77             644.26
   220.46             164.39             163.81             388.20             388.20             654.42
   235.93             161.35             163.97             393.31             391.29             650.17
   251.92             163.69             164.23             405.77             403.14             677.33
   268.44             212.03             213.89             458.24             462.00             654.97
```